### PR TITLE
Performance Improvements for write and sum for SHA2

### DIFF
--- a/src/SHA/SHA2.mo
+++ b/src/SHA/SHA2.mo
@@ -100,15 +100,18 @@ module {
         };
 
         private func block(bs : [Nat8]) {
-            var p = bs;
             var w : [var Nat32] = Array.init<Nat32>(64, 0);
+
             var h0 = h[0]; var h1 = h[1]; var h2 = h[2]; var h3 = h[3];
             var h4 = h[4]; var h5 = h[5]; var h6 = h[6]; var h7 = h[7];
-            while (64 <= p.size()) {
+
+            var start = 0;
+            var len = bs.size();
+            while (len >= 64) {
                 for (i in Iter.range(0, 15)) {
                     let j = i * 4;
-                    w[i] := Util.nat8to32(p[j]) << 24  | Util.nat8to32(p[j+1]) << 16
-                          | Util.nat8to32(p[j+2]) << 8 | Util.nat8to32(p[j+3]);
+                    w[i] := Util.nat8to32(bs[start + j + 0]) << 24  | Util.nat8to32(bs[start + j + 1]) << 16
+                          | Util.nat8to32(bs[start + j + 2]) << 8 | Util.nat8to32(bs[start + j + 3]);
                 };
                 for (i in Iter.range(16, 63)) {
                     let v1 = w[i-2];
@@ -127,7 +130,8 @@ module {
                 };
                 h0 +%= a; h1 +%= b; h2 +%= c; h3 +%= d;
                 h4 +%= e; h5 +%= f; h6 +%= g; h7 +%= h;
-                p := Util.removeN(64, p);
+                start += 64;
+                len -= 64;
             };
             h[0] := h0; h[1] := h1; h[2] := h2; h[3] := h3;
             h[4] := h4; h[5] := h5; h[6] := h6; h[7] := h7;

--- a/src/Utilities.mo
+++ b/src/Utilities.mo
@@ -59,6 +59,6 @@ module Utilities {
     };
 
     public func nat8to32(n : Nat8) : Nat32 {
-        Nat32.fromNat(Nat8.toNat(n));
+        Nat32.fromIntWrap(Nat8.toNat(n));
     };
 };

--- a/src/Utilities.mo
+++ b/src/Utilities.mo
@@ -1,4 +1,5 @@
 import Array "mo:base-0.7.3/Array";
+import Iter "mo:base-0.7.3/Iter";
 import Nat8 "mo:base-0.7.3/Nat8";
 import Nat32 "mo:base-0.7.3/Nat32";
 
@@ -15,6 +16,21 @@ module Utilities {
             dst[n + i] := src[i];
         };
         src.size();
+    };
+
+    public func copy_offset<T>(
+        n   : Nat, // Position to start writing.
+        o   : Nat, //offset
+        dst : [var T], 
+        src : [T]
+    ) : Nat {
+        let l = dst.size();
+        if (l < n) return 0;
+        label search for (i in Iter.range(0, src.size() - o - 1)) {
+            if (l <= n + i) return (i);
+            dst[n + i] := src[i + o];
+        };
+        src.size() - o;
     };
 
     public func removeN<T>(


### PR DESCRIPTION
Fixes #

## Proposed Changes

- I removed use of Array.tabulate from the SHA2 functions.
- I have not done this for HAMC, but I'd suggest doing so.
- I am now able to easily write 2MB x 12 writes in one cycle and as far as I can tell I can always calculate the hash even after adding 144 x 2MB blocks.

The tests are passing, but I have not yet tested the validity of a very large file.  

See:  https://m7sm4-2iaaa-aaaab-qabra-cai.raw.ic0.app/?tag=637638194 and https://forum.dfinity.org/t/progressive-sha256/17853
